### PR TITLE
fix: keyword filter visibility, details layout, and insert-listing-details action

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
- import React, { useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import "./index.css";
 
 // ---------- Types ----------
@@ -8,6 +8,54 @@ type Prompt = {
   category?: string;
   keywords?: string[];
   body: string;
+};
+
+const LISTING_FIELDS = [
+  "property type",
+  "address",
+  "city",
+  "neighborhood",
+  "bedrooms",
+  "bathrooms",
+  "sqft",
+  "price",
+  "hoa fee",
+  "year built",
+  "lot size",
+  "school district",
+  "key features",
+  "neighborhood characteristics",
+  "lifestyle benefits",
+  "word count",
+  "date",
+  "start time",
+  "end time",
+  "lead source",
+] as const;
+
+type ListingField = (typeof LISTING_FIELDS)[number];
+
+const DEFAULT_FIELD_VALUES: Record<ListingField, string> = {
+  "property type": "",
+  address: "",
+  city: "Miami",
+  neighborhood: "",
+  bedrooms: "3",
+  bathrooms: "2",
+  sqft: "",
+  price: "",
+  "hoa fee": "",
+  "year built": "",
+  "lot size": "",
+  "school district": "",
+  "key features": "ocean views, smart-home, chef’s kitchen",
+  "neighborhood characteristics": "",
+  "lifestyle benefits": "",
+  "word count": "170",
+  date: "",
+  "start time": "",
+  "end time": "",
+  "lead source": "",
 };
 
 // ---------- Data import (Vite JSON import) ----------
@@ -141,6 +189,7 @@ function Chip({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`__chip ${active ? "__chip--active" : ""}`}
       title={label}
@@ -163,6 +212,10 @@ function PromptCard({
   const body = prompt.body;
   const current = filled ?? body;
 
+  useEffect(() => {
+    setFilled(null);
+  }, [body, vars]);
+
   return (
     <div className="__pCard">
       <div className="__pHead">
@@ -173,6 +226,7 @@ function PromptCard({
         <div className="__btns">
           <button
             className="__btn"
+            type="button"
             onClick={() => {
               const next = fillAcrossDelimiters(body, expanded);
               setFilled(next);
@@ -182,6 +236,7 @@ function PromptCard({
           </button>
           <button
             className="__btn"
+            type="button"
             onClick={async () => {
               const ok = await safeCopy(current);
               if (!ok)
@@ -225,40 +280,47 @@ export default function App() {
     }));
   }, []);
 
-  // Build keyword universe from JSON
-  const allKeywords = useMemo(() => {
-    const set = new Set<string>();
-    prompts.forEach((p) => (p.keywords || []).forEach((k) => set.add(k)));
-    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  // Build keyword universe grouped by category for richer UI
+  const keywordGroups = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    prompts.forEach((p) => {
+      const category = (p.category || "Other").trim() || "Other";
+      if (!map.has(category)) {
+        map.set(category, new Set());
+      }
+      (p.keywords || []).forEach((keyword) => {
+        if (!keyword) return;
+        map.get(category)!.add(keyword);
+      });
+    });
+    return Array.from(map.entries())
+      .map(([category, values]) => ({
+        category,
+        keywords: Array.from(values).sort((a, b) => a.localeCompare(b)),
+      }))
+      .sort((a, b) => a.category.localeCompare(b.category));
   }, [prompts]);
+
+  const keywordUniverse = useMemo(() => {
+    const seen = new Set<string>();
+    keywordGroups.forEach(({ keywords }) => {
+      keywords.forEach((keyword) => {
+        if (!seen.has(keyword)) {
+          seen.add(keyword);
+        }
+      });
+    });
+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
+  }, [keywordGroups]);
 
   const [search, setSearch] = useState("");
   const [selectedKeywords, setSelectedKeywords] = useState<Set<string>>(
     () => new Set()
   );
 
-  const [vars, setVars] = useState<Record<string, string>>({
-    "property type": "",
-    address: "",
-    city: "Miami",
-    neighborhood: "",
-    bedrooms: "3",
-    bathrooms: "2",
-    sqft: "",
-    price: "",
-    "hoa fee": "",
-    "year built": "",
-    "lot size": "",
-    "school district": "",
-    "key features": "ocean views, smart-home, chef’s kitchen",
-    "neighborhood characteristics": "",
-    "lifestyle benefits": "",
-    "word count": "170",
-    date: "",
-    "start time": "",
-    "end time": "",
-    "lead source": "",
-  });
+  const [vars, setVars] = useState<Record<ListingField, string>>(
+    () => ({ ...DEFAULT_FIELD_VALUES })
+  );
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -273,11 +335,21 @@ export default function App() {
     });
   }, [prompts, search, selectedKeywords]);
 
-  const labels: string[] = [
-    "property type","address","city","neighborhood","bedrooms","bathrooms","sqft","price",
-    "hoa fee","year built","lot size","school district","key features",
-    "neighborhood characteristics","lifestyle benefits","word count","date","start time","end time","lead source",
-  ];
+  const clearFields = useCallback(() => {
+    setVars(() => ({ ...DEFAULT_FIELD_VALUES }));
+  }, []);
+
+  const handleFieldChange = useCallback(
+    (key: ListingField, value: string) => {
+      setVars((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const keywordList = useMemo(() => {
+    const items = Array.from(selectedKeywords.values());
+    return items.sort((a, b) => a.localeCompare(b));
+  }, [selectedKeywords]);
 
   function toggleKeyword(k: string) {
     setSelectedKeywords((prev) => {
@@ -290,146 +362,129 @@ export default function App() {
 
   return (
     <div className="__brts__root">
-      {/* Scoped styles */}
-      <style>{`
-        .__brts__root{max-width:1200px;margin:0 auto;padding:16px;color:#fff}
-        .__header{padding:20px 0}
-        .__title{margin:0;font-weight:800;line-height:1.1}
-        .__sub{opacity:.7}
-
-        .__row{display:grid;grid-template-columns:340px 1fr;gap:16px;align-items:start}
-        @media (max-width:980px){.__row{grid-template-columns:1fr}}
-
-        .__card{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);backdrop-filter:blur(8px);border-radius:16px;padding:16px}
-        .__card h3{margin:.25rem 0 .5rem 0}
-
-        .__inputs{display:grid;grid-template-columns:1fr 1fr;gap:10px}
-        .__inputs label{font-size:12px;opacity:.75}
-        .__inputs input{
-          width:100%;margin-top:4px;border-radius:10px;border:1px solid rgba(255,255,255,.18);
-          background:#0b0f17;color:#fff;padding:8px 10px;outline:none
-        }
-
-        .__muted{opacity:.7;font-size:12px}
-        .__search input{
-          width:100%;margin-top:6px;border-radius:10px;border:1px solid rgba(255,255,255,.18);
-          background:#0b0f17;color:#fff;padding:8px 10px;outline:none
-        }
-
-        .__chipsWrap{margin-top:10px;display:flex;flex-wrap:wrap;gap:8px}
-        .__chip{
-          padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.18);
-          background:rgba(255,255,255,.08);font-size:12px;color:#fff;cursor:pointer
-        }
-        .__chip--active{background:#fff;color:#000;border-color:#fff}
-
-        .__grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
-        @media (max-width:1200px){.__grid{grid-template-columns:repeat(2,1fr)}}
-        @media (max-width:700px){.__grid{grid-template-columns:1fr}}
-
-        .__pCard{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);border-radius:16px;padding:16px}
-        .__pHead{display:flex;justify-content:space-between;gap:8px}
-        .__cat{font-size:11px;text-transform:uppercase;opacity:.7}
-        .__pTitle{margin:6px 0 0 0}
-        .__btns{display:flex;gap:8px;flex-wrap:wrap}
-        .__btn{padding:8px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.22);background:#fff;color:#000;font-weight:700;cursor:pointer}
-        .__chipsRow{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
-        .__chipTag{padding:4px 8px;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.10);font-size:11px}
-        .__pBody{margin-top:10px;white-space:pre-wrap}
-      `}</style>
-
       {/* Header */}
       <header className="__header">
-        <h1 className="__title">Busy Realtors Time Saviour</h1>
-        <div className="__sub">Interactive Prompt Finder — Premium layout</div>
+        <span className="__eyebrow">Premium Prompt Toolkit</span>
+        <h1 className="__title">
+          Busy Realtors' Time Saver
+          <span className="__titleNote">
+            (For those who value time and optimize profit)
+          </span>
+        </h1>
+        <p className="__sub">
+          A refined library of high-converting prompts to help you launch listings,
+          nurture leads, and wow clients in minutes.
+        </p>
       </header>
 
-      {/* Top row: Listing details + Search */}
-      <div className="__row">
-        {/* Listing Details (no Apply info here) */}
-        <aside className="__card">
-          <h3>Listing Details</h3>
-          <div className="__inputs">
-            {labels.map((label) => {
-              const id = "f_" + label.replace(/\s+/g, "_");
-              return (
-                <div key={label} style={{ display: "flex", flexDirection: "column" }}>
-                  <label htmlFor={id}>[{label}]</label>
-                  <input
-                    id={id}
-                    value={vars[label] ?? ""}
-                    onChange={(e) => setVars((v) => ({ ...v, [label]: e.target.value }))}
-                  />
-                </div>
-              );
-            })}
-          </div>
-          <div style={{display:"flex",gap:8,marginTop:10,flexWrap:"wrap"}}>
-            <button
-              className="__btn"
-              onClick={() => setVars((v) => Object.fromEntries(Object.keys(v).map((k) => [k, ""])) as any)}
-            >
-              Clear
-            </button>
-          </div>
-        </aside>
-
-        {/* Search + Keywords */}
-        <section>
-          <div className="__card __search">
-            <label>Search</label>
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search titles, bodies, keywords…"
-            />
-            <div className="__muted" style={{ marginTop: 6 }}>
-              Showing: {filtered.length} / {prompts.length}
+      <main className="__layout">
+        {/* Top row: Listing details + Search */}
+        <div className="__topRow">
+          {/* Listing Details (no Apply info here) */}
+          <aside className="__card __card--details">
+            <h3>Listing Details</h3>
+            <div className="__inputs">
+              {LISTING_FIELDS.map((label) => {
+                const id = "f_" + label.replace(/\s+/g, "_");
+                return (
+                  <div key={label} className="__field">
+                    <label htmlFor={id}>[{label}]</label>
+                    <input
+                      id={id}
+                      value={vars[label] ?? ""}
+                      onChange={(e) => handleFieldChange(label, e.target.value)}
+                    />
+                  </div>
+                );
+              })}
             </div>
-          </div>
-
-          <div className="__card" style={{ marginTop: 12 }}>
-            <h3>Keywords</h3>
-            <div className="__chipsWrap">
-              {allKeywords.map((k) => (
-                <Chip
-                  key={k}
-                  label={k}
-                  active={selectedKeywords.has(k)}
-                  onClick={() => toggleKeyword(k)}
-                />
-              ))}
+            <div className="__actionsRow">
+              <button className="__btn" type="button" onClick={clearFields}>
+                Clear
+              </button>
             </div>
-            {selectedKeywords.size > 0 && (
-              <div className="__muted" style={{ marginTop: 8 }}>
-                Active: {Array.from(selectedKeywords).join(", ")} —{" "}
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setSelectedKeywords(new Set());
-                  }}
-                  style={{ color: "#fff" }}
-                >
-                  Clear
-                </a>
+          </aside>
+
+          {/* Search + Keywords */}
+          <section className="__colRight">
+            <div className="__card __search">
+              <label htmlFor="searchBox">Search</label>
+              <input
+                id="searchBox"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search titles, bodies, keywords…"
+              />
+              <div className="__muted __muted--spaced">
+                Showing: {filtered.length} / {prompts.length}
               </div>
-            )}
+            </div>
+
+            <div className="__card __card--keywords">
+              <div className="__cardTitleRow">
+                <h3>Keywords</h3>
+                <span className="__badge">Tap to filter</span>
+              </div>
+              <div className="__keywordSummary">
+                Browse {keywordUniverse.length} keywords across
+                {" "}
+                {keywordGroups.length} categories.
+              </div>
+              <div className="__keywordGroups">
+                {keywordGroups.map((group) => (
+                  <section key={group.category} className="__keywordGroup">
+                    <header className="__keywordGroupHead">
+                      <h4 className="__groupTitle">{group.category}</h4>
+                      <span className="__groupMeta">
+                        {group.keywords.length} keyword
+                        {group.keywords.length === 1 ? "" : "s"}
+                      </span>
+                    </header>
+                    <div className="__chipsWrap">
+                      {group.keywords.map((k) => (
+                        <Chip
+                          key={`${group.category}-${k}`}
+                          label={k}
+                          active={selectedKeywords.has(k)}
+                          onClick={() => toggleKeyword(k)}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+              <div className="__muted __muted--spaced">
+                {selectedKeywords.size > 0 ? (
+                  <>
+                    Active keywords: {keywordList.join(", ")} ·{" "}
+                    <button
+                      type="button"
+                      className="__linkBtn"
+                      onClick={() => setSelectedKeywords(new Set<string>())}
+                    >
+                      Clear
+                    </button>
+                  </>
+                ) : (
+                  <>Tap any keyword to filter the prompts below</>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+
+        {/* Prompt grid */}
+        <section className="__gridSection">
+          <div className="__grid">
+            {filtered.map((p) => (
+              <PromptCard key={p.id} prompt={p} vars={vars} />
+            ))}
           </div>
         </section>
-      </div>
+      </main>
 
-      {/* Prompt grid */}
-      <section style={{ marginTop: 16 }}>
-        <div className="__grid">
-          {filtered.map((p) => (
-            <PromptCard key={p.id} prompt={p} vars={vars} />
-          ))}
-        </div>
-      </section>
-
-      <footer style={{ padding: "24px 0", opacity: 0.7, fontSize: 12 }}>
-        © {new Date().getFullYear()} Busy Realtors Time Saviour — React build
+      <footer className="__footer">
+        © {new Date().getFullYear()} Busy Realtors' Time Saver · Crafted for agents who value time and optimize profit
       </footer>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,468 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Premium background helpers */
-.bg-radial-a { background: radial-gradient(closest-side, #12D6DF55, transparent); }
-.bg-radial-b { background: radial-gradient(closest-side, #7C9CFF55, transparent); }
+/* Base theming */
+*:where(*) {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system,
+    BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  background-color: #05060e;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-image: radial-gradient(circle at top left, #294cff38 0%, transparent 46%),
+    radial-gradient(circle at bottom right, #12d6df38 0%, transparent 54%),
+    linear-gradient(165deg, #05060e 0%, #090c19 55%, #03040c 100%);
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  padding: clamp(18px, 4vw, 36px);
+}
+
+#root {
+  width: 100%;
+}
+
+/* Layout shell */
+.__brts__root {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(18px, 3vw, 32px);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  position: relative;
+  z-index: 0;
+}
+
+.__brts__root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 34px;
+  background: linear-gradient(120deg, rgba(124, 156, 255, 0.18), rgba(18, 214, 223, 0.1));
+  filter: blur(160px);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  color: rgba(124, 156, 255, 0.9);
+  font-weight: 600;
+}
+
+.__title {
+  margin: 0;
+  font-weight: 800;
+  line-height: 1.05;
+  font-size: clamp(2rem, 3.4vw, 3.2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-shadow: 0 14px 40px rgba(7, 11, 27, 0.65);
+}
+
+.__titleNote {
+  font-size: clamp(1rem, 2.1vw, 1.2rem);
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.78);
+  letter-spacing: 0.06em;
+}
+
+.__sub {
+  opacity: 0.78;
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
+}
+
+.__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  position: relative;
+  z-index: 1;
+}
+
+.__topRow {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.__colRight {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.__card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(165deg, rgba(18, 24, 40, 0.92), rgba(18, 24, 40, 0.72));
+  backdrop-filter: blur(14px);
+  border-radius: 22px;
+  padding: 22px;
+  box-shadow: 0 16px 48px rgba(6, 9, 20, 0.55);
+  position: relative;
+  overflow: hidden;
+}
+
+.__card::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  pointer-events: none;
+}
+
+.__card h3 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.08rem;
+}
+
+.__card--details {
+  position: relative;
+}
+
+.__card--keywords {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.__keywordSummary {
+  font-size: 0.82rem;
+  opacity: 0.76;
+}
+
+.__cardTitleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.__badge {
+  background: linear-gradient(120deg, #7c9cff, #12d6df);
+  color: #05060e;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.__inputs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 16px;
+}
+
+.__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.__inputs label {
+  font-size: 0.72rem;
+  opacity: 0.75;
+  letter-spacing: 0.04em;
+}
+
+.__inputs input {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 11, 20, 0.92);
+  color: #fff;
+  padding: 9px 12px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.__inputs input:focus {
+  border-color: rgba(124, 156, 255, 0.85);
+  box-shadow: 0 0 0 2px rgba(124, 156, 255, 0.2);
+}
+
+.__actionsRow {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.__search label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.74;
+}
+
+.__search input {
+  width: 100%;
+  margin-top: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 11, 20, 0.92);
+  color: #fff;
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.__search input:focus {
+  border-color: rgba(18, 214, 223, 0.85);
+  box-shadow: 0 0 0 2px rgba(18, 214, 223, 0.2);
+}
+
+.__muted {
+  opacity: 0.72;
+  font-size: 0.75rem;
+}
+
+.__muted--spaced {
+  margin-top: 10px;
+}
+
+.__linkBtn {
+  appearance: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 0.75rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.__keywordGroups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+
+.__keywordGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(6, 12, 24, 0.48);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.__keywordGroupHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.__groupTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.82;
+}
+
+.__groupMeta {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.__chipsWrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.__chip {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.75rem;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.__chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(124, 156, 255, 0.7);
+}
+
+.__chip--active {
+  background: linear-gradient(120deg, #7c9cff, #12d6df);
+  color: #05060e;
+  border-color: transparent;
+  box-shadow: 0 8px 18px rgba(18, 214, 223, 0.35);
+}
+
+.__gridSection {
+  width: 100%;
+  margin-top: 6px;
+}
+
+.__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.__pCard {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(170deg, rgba(18, 24, 40, 0.9), rgba(14, 18, 32, 0.8));
+  border-radius: 20px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 16px 38px rgba(5, 8, 18, 0.4);
+  position: relative;
+}
+
+.__pHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.__cat {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  opacity: 0.66;
+  letter-spacing: 0.16em;
+}
+
+.__pTitle {
+  margin: 6px 0 0 0;
+}
+
+.__btns {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.__btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: linear-gradient(115deg, #ffffff, #d7e4ff);
+  color: #091020;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.__btn:active {
+  transform: translateY(1px);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.__chipsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: -4px;
+}
+
+.__chipTag {
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.7rem;
+}
+
+.__pBody {
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.__footer {
+  padding: 28px 0 34px;
+  opacity: 0.6;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+/* Responsiveness */
+@media (max-width: 1199px) {
+  .__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 980px) {
+  body {
+    padding: clamp(14px, 6vw, 28px);
+  }
+
+  .__topRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .__card {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 720px) {
+  .__inputs {
+    grid-template-columns: 1fr;
+  }
+
+  .__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .__btns {
+    width: 100%;
+  }
+
+  .__btns .__btn {
+    flex: 1 1 auto;
+  }
+}
+
+@media (max-width: 540px) {
+  .__title {
+    font-size: clamp(1.8rem, 8vw, 2.2rem);
+  }
+
+  .__titleNote {
+    font-size: 0.95rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- restructure the keywords panel so every prompt category renders with its own heading and chip list, making the category groupings immediately visible while preserving filtering behaviour
- refresh the keyword styling with summary text, category headers, and bordered group cards so the divided layout stays prominent across breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daa8bb296c832d9b14e1913db19221