### PR TITLE
Organize keyword chips by category and clean up UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import rawPrompts from "./data/prompts.json";
 import "./index.css";
 
@@ -8,6 +8,54 @@ type Prompt = {
   category?: string;
   keywords?: string[];
   body: string;
+};
+
+const LISTING_FIELDS = [
+  "property type",
+  "address",
+  "city",
+  "neighborhood",
+  "bedrooms",
+  "bathrooms",
+  "sqft",
+  "price",
+  "hoa fee",
+  "year built",
+  "lot size",
+  "school district",
+  "key features",
+  "neighborhood characteristics",
+  "lifestyle benefits",
+  "word count",
+  "date",
+  "start time",
+  "end time",
+  "lead source",
+] as const;
+
+type ListingField = (typeof LISTING_FIELDS)[number];
+
+const DEFAULT_VARS: Record<ListingField, string> = {
+  "property type": "",
+  address: "",
+  city: "Miami",
+  neighborhood: "",
+  bedrooms: "3",
+  bathrooms: "2",
+  sqft: "",
+  price: "",
+  "hoa fee": "",
+  "year built": "",
+  "lot size": "",
+  "school district": "",
+  "key features": "ocean views, smart-home, chef’s kitchen",
+  "neighborhood characteristics": "",
+  "lifestyle benefits": "",
+  "word count": "170",
+  date: "",
+  "start time": "",
+  "end time": "",
+  "lead source": "",
 };
 
 type KeywordGroup = {
@@ -168,6 +216,10 @@ function PromptCard({ prompt, vars }: PromptCardProps) {
   const expanded = useMemo(() => buildExpandedVars(vars), [vars]);
   const currentBody = filled ?? prompt.body;
 
+  useEffect(() => {
+    setFilled(null);
+  }, [prompt.body, vars]);
+
   return (
     <article className="prompt-card">
       <div className="prompt-card__head">
@@ -276,51 +328,9 @@ export default function App() {
   const summaryKeywords =
     activeKeywords.length > 0 ? activeKeywords : selectedKeywordsList;
 
-  const [vars, setVars] = useState<Record<string, string>>({
-    "property type": "",
-    address: "",
-    city: "Miami",
-    neighborhood: "",
-    bedrooms: "3",
-    bathrooms: "2",
-    sqft: "",
-    price: "",
-    "hoa fee": "",
-    "year built": "",
-    "lot size": "",
-    "school district": "",
-    "key features": "ocean views, smart-home, chef’s kitchen",
-    "neighborhood characteristics": "",
-    "lifestyle benefits": "",
-    "word count": "170",
-    date: "",
-    "start time": "",
-    "end time": "",
-    "lead source": "",
+  const [vars, setVars] = useState<Record<ListingField, string>>({
+    ...DEFAULT_VARS,
   });
-
-  const labels: string[] = [
-    "property type",
-    "address",
-    "city",
-    "neighborhood",
-    "bedrooms",
-    "bathrooms",
-    "sqft",
-    "price",
-    "hoa fee",
-    "year built",
-    "lot size",
-    "school district",
-    "key features",
-    "neighborhood characteristics",
-    "lifestyle benefits",
-    "word count",
-    "date",
-    "start time",
-    "end time",
-    "lead source",
-  ];
 
   const filteredPrompts = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -356,13 +366,7 @@ export default function App() {
   const clearKeywordFilters = () => setSelectedKeywords(new Set());
 
   const clearInputs = () => {
-    setVars((current) => {
-      const cleared: Record<string, string> = {};
-      Object.keys(current).forEach((key) => {
-        cleared[key] = "";
-      });
-      return cleared;
-    });
+    setVars({ ...DEFAULT_VARS });
   };
 
   return (
@@ -370,7 +374,7 @@ export default function App() {
       <div className="app-top">
         <aside className="card">
           <div className="inputs-grid">
-            {labels.map((label) => {
+            {LISTING_FIELDS.map((label) => {
               const id = `field-${label.replace(/\s+/g, "-")}`;
               return (
                 <label key={label} className="field" htmlFor={id}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,1027 +1,477 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/src/App.tsx b/src/App.tsx
-index f1674e5c78ed1af33a1857cb6d1686fda2751a82..234d075a7fe0a3c90203544fcae01084889f8475 100644
---- a/src/App.tsx
-+++ b/src/App.tsx
-@@ -1,587 +1,431 @@
-- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
--diff --git a/src/App.tsx b/src/App.tsx
--index eea2642a60ab1e9928b805d690a9fa8d613b23df..d376da97472a6651e670d0e59f66721d93d92cd4 100644
----- a/src/App.tsx
--+++ b/src/App.tsx
--@@ -1,37 +1,85 @@
--- import React, { useMemo, useState } from "react";
--+import React, { useCallback, useEffect, useMemo, useState } from "react";
-- import "./index.css";
-- 
-- // ---------- Types ----------
-- type Prompt = {
--   id: string;
--   title: string;
--   category?: string;
--   keywords?: string[];
--   body: string;
-- };
-- 
--+const LISTING_FIELDS = [
--+  "property type",
--+  "address",
--+  "city",
--+  "neighborhood",
--+  "bedrooms",
--+  "bathrooms",
--+  "sqft",
--+  "price",
--+  "hoa fee",
--+  "year built",
--+  "lot size",
--+  "school district",
--+  "key features",
--+  "neighborhood characteristics",
--+  "lifestyle benefits",
--+  "word count",
--+  "date",
--+  "start time",
--+  "end time",
--+  "lead source",
--+] as const;
--+
--+type ListingField = (typeof LISTING_FIELDS)[number];
--+
--+const DEFAULT_FIELD_VALUES: Record<ListingField, string> = {
--+  "property type": "",
--+  address: "",
--+  city: "Miami",
--+  neighborhood: "",
--+  bedrooms: "3",
--+  bathrooms: "2",
--+  sqft: "",
--+  price: "",
--+  "hoa fee": "",
--+  "year built": "",
--+  "lot size": "",
--+  "school district": "",
--+  "key features": "ocean views, smart-home, chef’s kitchen",
--+  "neighborhood characteristics": "",
--+  "lifestyle benefits": "",
--+  "word count": "170",
--+  date: "",
--+  "start time": "",
--+  "end time": "",
--+  "lead source": "",
--+};
--+
-- // ---------- Data import (Vite JSON import) ----------
-- import rawPrompts from "./data/prompts.json";
-- 
-- // ---------- Helpers ----------
-- const toKey = (s: string) =>
--   s
--     .toLowerCase()
--     .replace(/\u00A0/g, " ")
--     .replace(/[^\w\s-]/g, "")
--     .replace(/\s+/g, " ")
--     .trim();
-- 
-- const PH_PATTERNS: RegExp[] = [
--   /\[(.+?)\]/g, // [city]
--   /\{\{(.+?)\}\}/g, // {{city}}
--   /\{(.+?)\}/g, // {city}
--   /<(.+?)>/g, // <city>
--   /\((.+?)\)/g, // (city)
-- ];
-- 
-- const ALIASES: Record<string, string[]> = {
--   "number of bedrooms": ["bedrooms", "beds"],
--   "number of bathrooms": ["bathrooms", "baths"],
--   "unique selling points": ["key features", "features"],
--   "property type": ["type", "ptype"],
--diff --git a/src/App.tsx b/src/App.tsx
--index eea2642a60ab1e9928b805d690a9fa8d613b23df..d376da97472a6651e670d0e59f66721d93d92cd4 100644
----- a/src/App.tsx
--+++ b/src/App.tsx
--@@ -119,318 +167,325 @@ async function safeCopy(text: string) {
--     ta.style.position = "fixed";
--     ta.style.top = "-9999px";
--     document.body.appendChild(ta);
--     ta.focus();
--     ta.select();
--     const ok = document.execCommand("copy");
--     document.body.removeChild(ta);
--     return ok;
--   } catch {
--     return false;
--   }
-- }
-- 
-- // ---------- Small UI atoms ----------
-- function Chip({
--   label,
--   active,
--   onClick,
-- }: {
--   label: string;
--   active: boolean;
--   onClick: () => void;
-- }) {
--   return (
--     <button
--+      type="button"
--       onClick={onClick}
--       className={`__chip ${active ? "__chip--active" : ""}`}
--       title={label}
--     >
--       {label}
--     </button>
--   );
-- }
-- 
-- // ---------- Prompt Card ----------
-- function PromptCard({
--   prompt,
--   vars,
-- }: {
--   prompt: Prompt;
--   vars: Record<string, string>;
-- }) {
--   const [filled, setFilled] = useState<string | null>(null);
--   const expanded = useMemo(() => buildExpandedVars(vars), [vars]);
--   const body = prompt.body;
--   const current = filled ?? body;
-- 
--+  useEffect(() => {
--+    setFilled(null);
--+  }, [body, vars]);
--+
--   return (
--     <div className="__pCard">
--       <div className="__pHead">
--         <div>
--           <div className="__cat">{prompt.category || "Other"}</div>
--           <h4 className="__pTitle">{prompt.title}</h4>
--         </div>
--         <div className="__btns">
--           <button
--             className="__btn"
--+            type="button"
--             onClick={() => {
--               const next = fillAcrossDelimiters(body, expanded);
--               setFilled(next);
--             }}
--           >
--             Insert Listing Details
--           </button>
--           <button
--             className="__btn"
--+            type="button"
--             onClick={async () => {
--               const ok = await safeCopy(current);
--               if (!ok)
--                 alert("Copied text selected. If blocked, use Ctrl/Cmd+C.");
--             }}
--           >
--             Copy
--           </button>
--         </div>
--       </div>
-- 
--       <div
--         className="__pBody"
--         dangerouslySetInnerHTML={{ __html: escapeHtml(current) }}
--       />
-- 
--       {!!(prompt.keywords && prompt.keywords.length) && (
--         <div className="__chipsRow">
--           {prompt.keywords!.map((k) => (
--             <span key={k} className="__chipTag">
--               #{k}
--             </span>
--           ))}
--         </div>
--       )}
--     </div>
--   );
-- }
-- 
-- // ---------- Main Component ----------
-- export default function App() {
--   // Normalize prompts from JSON
--   const prompts: Prompt[] = useMemo(() => {
--     const arr = (rawPrompts as any[]) || [];
--     return arr.map((p, i) => ({
--       id: String(p.id ?? i),
--       title: p.title ?? `Untitled #${i + 1}`,
--       category: p.category ?? "Other",
--       keywords: Array.isArray(p.keywords) ? p.keywords : [],
--       body: p.body ?? p.text ?? p.prompt ?? "",
--     }));
--   }, []);
-- 
---  // Build keyword universe from JSON
---  const allKeywords = useMemo(() => {
---    const set = new Set<string>();
---    prompts.forEach((p) => (p.keywords || []).forEach((k) => set.add(k)));
---    return Array.from(set).sort((a, b) => a.localeCompare(b));
--+  // Build keyword universe grouped by category for richer UI
--+  const keywordGroups = useMemo(() => {
--+    const map = new Map<string, Set<string>>();
--+    prompts.forEach((p) => {
--+      const category = (p.category || "Other").trim() || "Other";
--+      if (!map.has(category)) {
--+        map.set(category, new Set());
--+      }
--+      (p.keywords || []).forEach((keyword) => {
--+        if (!keyword) return;
--+        map.get(category)!.add(keyword);
--+      });
--+    });
--+    return Array.from(map.entries())
--+      .map(([category, values]) => ({
--+        category,
--+        keywords: Array.from(values).sort((a, b) => a.localeCompare(b)),
--+      }))
--+      .sort((a, b) => a.category.localeCompare(b.category));
--   }, [prompts]);
-- 
--+  const keywordUniverse = useMemo(() => {
--+    const seen = new Set<string>();
--+    keywordGroups.forEach(({ keywords }) => {
--+      keywords.forEach((keyword) => {
--+        if (!seen.has(keyword)) {
--+          seen.add(keyword);
--+        }
--+      });
--+    });
--+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
--+  }, [keywordGroups]);
--+
--   const [search, setSearch] = useState("");
--   const [selectedKeywords, setSelectedKeywords] = useState<Set<string>>(
--     () => new Set()
--   );
-- 
---  const [vars, setVars] = useState<Record<string, string>>({
---    "property type": "",
---    address: "",
---    city: "Miami",
---    neighborhood: "",
---    bedrooms: "3",
---    bathrooms: "2",
---    sqft: "",
---    price: "",
---    "hoa fee": "",
---    "year built": "",
---    "lot size": "",
---    "school district": "",
---    "key features": "ocean views, smart-home, chef’s kitchen",
---    "neighborhood characteristics": "",
---    "lifestyle benefits": "",
---    "word count": "170",
---    date: "",
---    "start time": "",
---    "end time": "",
---    "lead source": "",
---  });
--+  const [vars, setVars] = useState<Record<ListingField, string>>(
--+    () => ({ ...DEFAULT_FIELD_VALUES })
--+  );
-- 
--   const filtered = useMemo(() => {
--     const q = search.trim().toLowerCase();
--     return prompts.filter((p) => {
--       if (selectedKeywords.size > 0) {
--         const hasAny = (p.keywords || []).some((k) => selectedKeywords.has(k));
--         if (!hasAny) return false;
--       }
--       if (!q) return true;
--       const hay = (p.title + "\n" + p.body + "\n" + (p.keywords || []).join(" ")).toLowerCase();
--       return hay.includes(q);
--     });
--   }, [prompts, search, selectedKeywords]);
-- 
---  const labels: string[] = [
---    "property type","address","city","neighborhood","bedrooms","bathrooms","sqft","price",
---    "hoa fee","year built","lot size","school district","key features",
---    "neighborhood characteristics","lifestyle benefits","word count","date","start time","end time","lead source",
---  ];
--+  const clearFields = useCallback(() => {
--+    setVars(() => ({ ...DEFAULT_FIELD_VALUES }));
--+  }, []);
--+
--+  const handleFieldChange = useCallback(
--+    (key: ListingField, value: string) => {
--+      setVars((prev) => ({ ...prev, [key]: value }));
--+    },
--+    []
--+  );
--+
--+  const keywordList = useMemo(() => {
--+    const items = Array.from(selectedKeywords.values());
--+    return items.sort((a, b) => a.localeCompare(b));
--+  }, [selectedKeywords]);
-- 
--   function toggleKeyword(k: string) {
--     setSelectedKeywords((prev) => {
--       const next = new Set(prev);
--       if (next.has(k)) next.delete(k);
--       else next.add(k);
--       return next;
--     });
--   }
-- 
--   return (
--     <div className="__brts__root">
---      {/* Scoped styles */}
---      <style>{`
---        .__brts__root{max-width:1200px;margin:0 auto;padding:16px;color:#fff}
---        .__header{padding:20px 0}
---        .__title{margin:0;font-weight:800;line-height:1.1}
---        .__sub{opacity:.7}
---
---        .__row{display:grid;grid-template-columns:340px 1fr;gap:16px;align-items:start}
---        @media (max-width:980px){.__row{grid-template-columns:1fr}}
---
---        .__card{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);backdrop-filter:blur(8px);border-radius:16px;padding:16px}
---        .__card h3{margin:.25rem 0 .5rem 0}
---
---        .__inputs{display:grid;grid-template-columns:1fr 1fr;gap:10px}
---        .__inputs label{font-size:12px;opacity:.75}
---        .__inputs input{
---          width:100%;margin-top:4px;border-radius:10px;border:1px solid rgba(255,255,255,.18);
---          background:#0b0f17;color:#fff;padding:8px 10px;outline:none
---        }
---
---        .__muted{opacity:.7;font-size:12px}
---        .__search input{
---          width:100%;margin-top:6px;border-radius:10px;border:1px solid rgba(255,255,255,.18);
---          background:#0b0f17;color:#fff;padding:8px 10px;outline:none
---        }
---
---        .__chipsWrap{margin-top:10px;display:flex;flex-wrap:wrap;gap:8px}
---        .__chip{
---          padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.18);
---          background:rgba(255,255,255,.08);font-size:12px;color:#fff;cursor:pointer
---        }
---        .__chip--active{background:#fff;color:#000;border-color:#fff}
---
---        .__grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
---        @media (max-width:1200px){.__grid{grid-template-columns:repeat(2,1fr)}}
---        @media (max-width:700px){.__grid{grid-template-columns:1fr}}
---
---        .__pCard{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);border-radius:16px;padding:16px}
---        .__pHead{display:flex;justify-content:space-between;gap:8px}
---        .__cat{font-size:11px;text-transform:uppercase;opacity:.7}
---        .__pTitle{margin:6px 0 0 0}
---        .__btns{display:flex;gap:8px;flex-wrap:wrap}
---        .__btn{padding:8px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.22);background:#fff;color:#000;font-weight:700;cursor:pointer}
---        .__chipsRow{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
---        .__chipTag{padding:4px 8px;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.10);font-size:11px}
---        .__pBody{margin-top:10px;white-space:pre-wrap}
---      `}</style>
---
--       {/* Header */}
--       <header className="__header">
---        <h1 className="__title">Busy Realtors Time Saviour</h1>
---        <div className="__sub">Interactive Prompt Finder — Premium layout</div>
--+        <span className="__eyebrow">Premium Prompt Toolkit</span>
--+        <h1 className="__title">
--+          Busy Realtors' Time Saver
--+          <span className="__titleNote">
--+            (For those who value time and optimize profit)
--+          </span>
--+        </h1>
--+        <p className="__sub">
--+          A refined library of high-converting prompts to help you launch listings,
--+          nurture leads, and wow clients in minutes.
--+        </p>
--       </header>
-- 
---      {/* Top row: Listing details + Search */}
---      <div className="__row">
---        {/* Listing Details (no Apply info here) */}
---        <aside className="__card">
---          <h3>Listing Details</h3>
---          <div className="__inputs">
---            {labels.map((label) => {
---              const id = "f_" + label.replace(/\s+/g, "_");
---              return (
---                <div key={label} style={{ display: "flex", flexDirection: "column" }}>
---                  <label htmlFor={id}>[{label}]</label>
---                  <input
---                    id={id}
---                    value={vars[label] ?? ""}
---                    onChange={(e) => setVars((v) => ({ ...v, [label]: e.target.value }))}
---                  />
---                </div>
---              );
---            })}
---          </div>
---          <div style={{display:"flex",gap:8,marginTop:10,flexWrap:"wrap"}}>
---            <button
---              className="__btn"
---              onClick={() => setVars((v) => Object.fromEntries(Object.keys(v).map((k) => [k, ""])) as any)}
---            >
---              Clear
---            </button>
---          </div>
---        </aside>
---
---        {/* Search + Keywords */}
---        <section>
---          <div className="__card __search">
---            <label>Search</label>
---            <input
---              value={search}
---              onChange={(e) => setSearch(e.target.value)}
---              placeholder="Search titles, bodies, keywords…"
---            />
---            <div className="__muted" style={{ marginTop: 6 }}>
---              Showing: {filtered.length} / {prompts.length}
--+      <main className="__layout">
--+        {/* Top row: Listing details + Search */}
--+        <div className="__topRow">
--+          {/* Listing Details (no Apply info here) */}
--+          <aside className="__card __card--details">
--+            <h3>Listing Details</h3>
--+            <div className="__inputs">
--+              {LISTING_FIELDS.map((label) => {
--+                const id = "f_" + label.replace(/\s+/g, "_");
--+                return (
--+                  <div key={label} className="__field">
--+                    <label htmlFor={id}>[{label}]</label>
--+                    <input
--+                      id={id}
--+                      value={vars[label] ?? ""}
--+                      onChange={(e) => handleFieldChange(label, e.target.value)}
--+                    />
--+                  </div>
--+                );
--+              })}
--             </div>
---          </div>
---
---          <div className="__card" style={{ marginTop: 12 }}>
---            <h3>Keywords</h3>
---            <div className="__chipsWrap">
---              {allKeywords.map((k) => (
---                <Chip
---                  key={k}
---                  label={k}
---                  active={selectedKeywords.has(k)}
---                  onClick={() => toggleKeyword(k)}
---                />
---              ))}
--+            <div className="__actionsRow">
--+              <button className="__btn" type="button" onClick={clearFields}>
--+                Clear
--+              </button>
--             </div>
---            {selectedKeywords.size > 0 && (
---              <div className="__muted" style={{ marginTop: 8 }}>
---                Active: {Array.from(selectedKeywords).join(", ")} —{" "}
---                <a
---                  href="#"
---                  onClick={(e) => {
---                    e.preventDefault();
---                    setSelectedKeywords(new Set());
---                  }}
---                  style={{ color: "#fff" }}
---                >
---                  Clear
---                </a>
--+          </aside>
--+
--+          {/* Search + Keywords */}
--+          <section className="__colRight">
--+            <div className="__card __search">
--+              <label htmlFor="searchBox">Search</label>
--+              <input
--+                id="searchBox"
--+                value={search}
--+                onChange={(e) => setSearch(e.target.value)}
--+                placeholder="Search titles, bodies, keywords…"
--+              />
--+              <div className="__muted __muted--spaced">
--+                Showing: {filtered.length} / {prompts.length}
--               </div>
---            )}
---          </div>
---        </section>
---      </div>
--+            </div>
-- 
---      {/* Prompt grid */}
---      <section style={{ marginTop: 16 }}>
---        <div className="__grid">
---          {filtered.map((p) => (
---            <PromptCard key={p.id} prompt={p} vars={vars} />
---          ))}
--+            <div className="__card __card--keywords">
--+              <div className="__cardTitleRow">
--+                <h3>Keywords</h3>
--+                <span className="__badge">Tap to filter</span>
--+              </div>
--+              <div className="__keywordSummary">
--+                Browse {keywordUniverse.length} keywords across
--+                {" "}
--+                {keywordGroups.length} categories.
--+              </div>
--+              <div className="__keywordGroups">
--+                {keywordGroups.map((group) => (
--+                  <section key={group.category} className="__keywordGroup">
--+                    <header className="__keywordGroupHead">
--+                      <h4 className="__groupTitle">{group.category}</h4>
--+                      <span className="__groupMeta">
--+                        {group.keywords.length} keyword
--+                        {group.keywords.length === 1 ? "" : "s"}
--+                      </span>
--+                    </header>
--+                    <div className="__chipsWrap">
--+                      {group.keywords.map((k) => (
--+                        <Chip
--+                          key={`${group.category}-${k}`}
--+                          label={k}
--+                          active={selectedKeywords.has(k)}
--+                          onClick={() => toggleKeyword(k)}
--+                        />
--+                      ))}
--+                    </div>
--+                  </section>
--+                ))}
--+              </div>
--+              <div className="__muted __muted--spaced">
--+                {selectedKeywords.size > 0 ? (
--+                  <>
--+                    Active keywords: {keywordList.join(", ")} ·{" "}
--+                    <button
--+                      type="button"
--+                      className="__linkBtn"
--+                      onClick={() => setSelectedKeywords(new Set<string>())}
--+                    >
--+                      Clear
--+                    </button>
--+                  </>
--+                ) : (
--+                  <>Tap any keyword to filter the prompts below</>
--+                )}
--+              </div>
--+            </div>
--+          </section>
--         </div>
---      </section>
-- 
---      <footer style={{ padding: "24px 0", opacity: 0.7, fontSize: 12 }}>
---        © {new Date().getFullYear()} Busy Realtors Time Saviour — React build
--+        {/* Prompt grid */}
--+        <section className="__gridSection">
--+          <div className="__grid">
--+            {filtered.map((p) => (
--+              <PromptCard key={p.id} prompt={p} vars={vars} />
--+            ))}
--+          </div>
--+        </section>
--+      </main>
--+
--+      <footer className="__footer">
--+        © {new Date().getFullYear()} Busy Realtors' Time Saver · Crafted for agents who value time and optimize profit
--       </footer>
--     </div>
--   );
-- }
-- 
--EOF
--)
-+import { useMemo, useState } from "react";
-+import rawPrompts from "./data/prompts.json";
-+import "./index.css";
-+
-+type Prompt = {
-+  id: string;
-+  title: string;
-+  category?: string;
-+  keywords?: string[];
-+  body: string;
-+};
-+
-+const PLACEHOLDER_PATTERNS: RegExp[] = [
-+  /\[(.+?)\]/g,
-+  /\{\{(.+?)\}\}/g,
-+  /\{(.+?)\}/g,
-+  /<(.+?)>/g,
-+  /\((.+?)\)/g,
-+];
-+
-+const ALIASES: Record<string, string[]> = {
-+  "number of bedrooms": ["bedrooms", "beds"],
-+  "number of bathrooms": ["bathrooms", "baths"],
-+  "unique selling points": ["key features", "features"],
-+  "property type": ["type", "ptype"],
-+  "neighbourhood": ["neighborhood"],
-+  "neighbourhood characteristics": ["neighborhood characteristics"],
-+  "city/town": ["city"],
-+  "year built": ["built year", "yr built"],
-+  "hoa fee": ["hoa", "hoa fees"],
-+  "hoa fees": ["hoa fee", "hoa"],
-+};
-+
-+function toKey(value: string) {
-+  return value
-+    .toLowerCase()
-+    .replace(/\u00a0/g, " ")
-+    .replace(/[^\w\s-]/g, "")
-+    .replace(/\s+/g, " ")
-+    .trim();
-+}
-+
-+function buildExpandedVars(vars: Record<string, string>) {
-+  const base: Record<string, string> = {};
-+  for (const key of Object.keys(vars)) {
-+    const value = String(vars[key] ?? "").trim();
-+    if (!value) continue;
-+    base[toKey(key)] = value;
-+  }
-+
-+  for (const canonical of Object.keys(ALIASES)) {
-+    const canonicalKey = toKey(canonical);
-+    if (!base[canonicalKey]) {
-+      for (const alias of ALIASES[canonical]) {
-+        const aliasValue = base[toKey(alias)];
-+        if (aliasValue) {
-+          base[canonicalKey] = aliasValue;
-+          break;
-+        }
-+      }
-+    }
-+  }
-+
-+  for (const canonical of Object.keys(ALIASES)) {
-+    const canonicalKey = toKey(canonical);
-+    const canonicalValue = base[canonicalKey];
-+    if (!canonicalValue) continue;
-+    for (const alias of ALIASES[canonical]) {
-+      const aliasKey = toKey(alias);
-+      if (!base[aliasKey]) base[aliasKey] = canonicalValue;
-+    }
-+  }
-+
-+  return base;
-+}
-+
-+function fillAcrossDelimiters(body: string, expanded: Record<string, string>) {
-+  let next = body;
-+  for (const pattern of PLACEHOLDER_PATTERNS) {
-+    next = next.replace(pattern, (_, raw: string) => {
-+      const key = toKey(raw);
-+      return expanded[key] ? expanded[key] : `[${raw}]`;
-+    });
-+  }
-+
-+  next = next.replace(/\[(number of .+?)\]/gi, (_, raw: string) => {
-+    const match = /^number of (.+)$/i.exec(raw);
-+    if (!match) return `[${raw}]`;
-+    const baseKey = toKey(match[1]);
-+    const variations = [
-+      baseKey,
-+      baseKey.replace(/s\b/, ""),
-+      baseKey.replace(/s\b/, "") + "s",
-+    ];
-+    for (const candidate of variations) {
-+      if (expanded[candidate]) return expanded[candidate];
-+    }
-+    return `[${raw}]`;
-+  });
-+
-+  return next;
-+}
-+
-+function escapeHtml(value: string) {
-+  return value
-+    .replace(/&/g, "&amp;")
-+    .replace(/</g, "&lt;")
-+    .replace(/>/g, "&gt;")
-+    .replace(/\n/g, "<br/>");
-+}
-+
-+async function safeCopy(text: string) {
-+  try {
-+    if (navigator.clipboard?.writeText) {
-+      await navigator.clipboard.writeText(text);
-+      return true;
-+    }
-+  } catch {}
-+
-+  try {
-+    const textarea = document.createElement("textarea");
-+    textarea.value = text;
-+    textarea.setAttribute("readonly", "");
-+    textarea.style.position = "fixed";
-+    textarea.style.top = "-9999px";
-+    document.body.appendChild(textarea);
-+    textarea.focus();
-+    textarea.select();
-+    const ok = document.execCommand("copy");
-+    document.body.removeChild(textarea);
-+    return ok;
-+  } catch {
-+    return false;
-+  }
-+}
-+
-+type ChipProps = {
-+  label: string;
-+  active: boolean;
-+  onClick: () => void;
-+};
-+
-+function Chip({ label, active, onClick }: ChipProps) {
-+  return (
-+    <button
-+      type="button"
-+      onClick={onClick}
-+      className={`chip${active ? " chip--active" : ""}`}
-+      title={label}
-+    >
-+      {label}
-+    </button>
-+  );
-+}
-+
-+type PromptCardProps = {
-+  prompt: Prompt;
-+  vars: Record<string, string>;
-+};
-+
-+function PromptCard({ prompt, vars }: PromptCardProps) {
-+  const [filled, setFilled] = useState<string | null>(null);
-+  const expanded = useMemo(() => buildExpandedVars(vars), [vars]);
-+  const currentBody = filled ?? prompt.body;
-+
-+  return (
-+    <article className="prompt-card">
-+      <div className="prompt-card__head">
-+        <div>
-+          <div className="prompt-card__meta">
-+            {prompt.category || "Other"}
-+          </div>
-+          <h3 className="prompt-card__title">{prompt.title}</h3>
-+        </div>
-+        <div className="prompt-card__actions">
-+          <button
-+            type="button"
-+            className="button"
-+            onClick={() => setFilled(fillAcrossDelimiters(prompt.body, expanded))}
-+          >
-+            Insert listing details
-+          </button>
-+          <button
-+            type="button"
-+            className="button button--ghost"
-+            onClick={async () => {
-+              const ok = await safeCopy(currentBody);
-+              if (!ok)
-+                alert("Copy blocked. Please select the text and use Cmd/Ctrl + C.");
-+            }}
-+          >
-+            Copy
-+          </button>
-+        </div>
-+      </div>
-+
-+      <div
-+        className="prompt-card__body"
-+        dangerouslySetInnerHTML={{ __html: escapeHtml(currentBody) }}
-+      />
-+
-+      {!!(prompt.keywords && prompt.keywords.length) && (
-+        <div className="prompt-card__tags">
-+          {prompt.keywords!.map((keyword) => (
-+            <span key={keyword} className="prompt-card__tag">
-+              #{keyword}
-+            </span>
-+          ))}
-+        </div>
-+      )}
-+    </article>
-+  );
-+}
-+
-+export default function App() {
-+  const prompts: Prompt[] = useMemo(() => {
-+    const list = (rawPrompts as Prompt[]) || [];
-+    return list.map((prompt, index) => ({
-+      id: String(prompt.id ?? index),
-+      title: prompt.title ?? `Untitled #${index + 1}`,
-+      category: prompt.category ?? "Other",
-+      keywords: Array.isArray(prompt.keywords) ? prompt.keywords : [],
-+      body: prompt.body ?? (prompt as any).text ?? (prompt as any).prompt ?? "",
-+    }));
-+  }, []);
-+
-+  const allKeywords = useMemo(() => {
-+    const set = new Set<string>();
-+    prompts.forEach((prompt) =>
-+      (prompt.keywords || []).forEach((keyword) => set.add(keyword))
-+    );
-+    return Array.from(set).sort((a, b) => a.localeCompare(b));
-+  }, [prompts]);
-+
-+  const [search, setSearch] = useState("");
-+  const [selectedKeywords, setSelectedKeywords] = useState<Set<string>>(
-+    () => new Set()
-+  );
-+
-+  const [vars, setVars] = useState<Record<string, string>>({
-+    "property type": "",
-+    address: "",
-+    city: "Miami",
-+    neighborhood: "",
-+    bedrooms: "3",
-+    bathrooms: "2",
-+    sqft: "",
-+    price: "",
-+    "hoa fee": "",
-+    "year built": "",
-+    "lot size": "",
-+    "school district": "",
-+    "key features": "ocean views, smart-home, chef’s kitchen",
-+    "neighborhood characteristics": "",
-+    "lifestyle benefits": "",
-+    "word count": "170",
-+    date: "",
-+    "start time": "",
-+    "end time": "",
-+    "lead source": "",
-+  });
-+
-+  const labels: string[] = [
-+    "property type",
-+    "address",
-+    "city",
-+    "neighborhood",
-+    "bedrooms",
-+    "bathrooms",
-+    "sqft",
-+    "price",
-+    "hoa fee",
-+    "year built",
-+    "lot size",
-+    "school district",
-+    "key features",
-+    "neighborhood characteristics",
-+    "lifestyle benefits",
-+    "word count",
-+    "date",
-+    "start time",
-+    "end time",
-+    "lead source",
-+  ];
-+
-+  const filteredPrompts = useMemo(() => {
-+    const query = search.trim().toLowerCase();
-+    return prompts.filter((prompt) => {
-+      if (selectedKeywords.size > 0) {
-+        const hasKeyword = (prompt.keywords || []).some((keyword) =>
-+          selectedKeywords.has(keyword)
-+        );
-+        if (!hasKeyword) return false;
-+      }
-+
-+      if (!query) return true;
-+      const haystack = (
-+        prompt.title +
-+        "\n" +
-+        prompt.body +
-+        "\n" +
-+        (prompt.keywords || []).join(" ")
-+      ).toLowerCase();
-+      return haystack.includes(query);
-+    });
-+  }, [prompts, search, selectedKeywords]);
-+
-+  const toggleKeyword = (keyword: string) => {
-+    setSelectedKeywords((previous) => {
-+      const next = new Set(previous);
-+      if (next.has(keyword)) next.delete(keyword);
-+      else next.add(keyword);
-+      return next;
-+    });
-+  };
-+
-+  const clearKeywordFilters = () => setSelectedKeywords(new Set());
-+
-+  const clearInputs = () => {
-+    setVars((current) => {
-+      const cleared: Record<string, string> = {};
-+      Object.keys(current).forEach((key) => {
-+        cleared[key] = "";
-+      });
-+      return cleared;
-+    });
-+  };
-+
-+  return (
-+    <div className="app-shell">
-+      <div className="app-top">
-+        <aside className="card">
-+          <div className="card__header">
-+            <h2 className="card__title">Listing details</h2>
-+            <span className="card__badge">Inputs</span>
-+          </div>
-+
-+          <div className="inputs-grid">
-+            {labels.map((label) => {
-+              const id = `field-${label.replace(/\s+/g, "-")}`;
-+              return (
-+                <label key={label} className="field" htmlFor={id}>
-+                  <span className="field__label">[{label}]</span>
-+                  <input
-+                    id={id}
-+                    value={vars[label] ?? ""}
-+                    onChange={(event) =>
-+                      setVars((previous) => ({
-+                        ...previous,
-+                        [label]: event.target.value,
-+                      }))
-+                    }
-+                  />
-+                </label>
-+              );
-+            })}
-+          </div>
-+
-+          <div className="actions">
-+            <button type="button" className="button" onClick={clearInputs}>
-+              Clear
-+            </button>
-+          </div>
-+        </aside>
-+
-+        <div className="col-right">
-+          <section className="card search-card">
-+            <label htmlFor="search">Search</label>
-+            <input
-+              id="search"
-+              value={search}
-+              onChange={(event) => setSearch(event.target.value)}
-+              placeholder="Search titles, bodies, keywords…"
-+            />
-+            <p className="muted">
-+              Showing {filteredPrompts.length} of {prompts.length}
-+            </p>
-+          </section>
-+
-+          <section className="card keywords-card">
-+            <div className="card__header" style={{ marginBottom: 0 }}>
-+              <h2 className="card__title">Keywords</h2>
-+            </div>
-+            <div className="chip-grid">
-+              {allKeywords.map((keyword) => (
-+                <Chip
-+                  key={keyword}
-+                  label={keyword}
-+                  active={selectedKeywords.has(keyword)}
-+                  onClick={() => toggleKeyword(keyword)}
-+                />
-+              ))}
-+            </div>
-+            {selectedKeywords.size > 0 && (
-+              <div className="keyword-summary">
-+                Active: {Array.from(selectedKeywords).join(", ")} —{" "}
-+                <button
-+                  type="button"
-+                  className="link-button"
-+                  onClick={clearKeywordFilters}
-+                >
-+                  Clear
-+                </button>
-+              </div>
-+            )}
-+          </section>
-+        </div>
-+      </div>
-+
-+      <section className="grid-section">
-+        {filteredPrompts.length > 0 ? (
-+          <div className="grid">
-+            {filteredPrompts.map((prompt) => (
-+              <PromptCard key={prompt.id} prompt={prompt} vars={vars} />
-+            ))}
-+          </div>
-+        ) : (
-+          <div className="empty-state">
-+            No prompts match your filters yet. Try adjusting the search or
-+            keyword chips.
-+          </div>
-+        )}
-+      </section>
-+
-+      <footer className="footer">
-+        © {new Date().getFullYear()} Busy Realtors Time Saviour — Prompt finder
-+        toolkit
-+      </footer>
-+    </div>
-+  );
-+}
+import { useMemo, useState } from "react";
+import rawPrompts from "./data/prompts.json";
+import "./index.css";
+
+type Prompt = {
+  id: string;
+  title: string;
+  category?: string;
+  keywords?: string[];
+  body: string;
+};
+
+type KeywordGroup = {
+  category: string;
+  keywords: string[];
+};
+
+const PLACEHOLDER_PATTERNS: RegExp[] = [
+  /\[(.+?)\]/g,
+  /\{\{(.+?)\}\}/g,
+  /\{(.+?)\}/g,
+  /<(.+?)>/g,
+  /\((.+?)\)/g,
+];
+
+const ALIASES: Record<string, string[]> = {
+  "number of bedrooms": ["bedrooms", "beds"],
+  "number of bathrooms": ["bathrooms", "baths"],
+  "unique selling points": ["key features", "features"],
+  "property type": ["type", "ptype"],
+  "neighbourhood": ["neighborhood"],
+  "neighbourhood characteristics": ["neighborhood characteristics"],
+  "city/town": ["city"],
+  "year built": ["built year", "yr built"],
+  "hoa fee": ["hoa", "hoa fees"],
+  "hoa fees": ["hoa fee", "hoa"],
+};
+
+function toKey(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/\u00a0/g, " ")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildExpandedVars(vars: Record<string, string>) {
+  const base: Record<string, string> = {};
+  for (const key of Object.keys(vars)) {
+    const value = String(vars[key] ?? "").trim();
+    if (!value) continue;
+    base[toKey(key)] = value;
+  }
+
+  for (const canonical of Object.keys(ALIASES)) {
+    const canonicalKey = toKey(canonical);
+    if (!base[canonicalKey]) {
+      for (const alias of ALIASES[canonical]) {
+        const aliasValue = base[toKey(alias)];
+        if (aliasValue) {
+          base[canonicalKey] = aliasValue;
+          break;
+        }
+      }
+    }
+  }
+
+  for (const canonical of Object.keys(ALIASES)) {
+    const canonicalKey = toKey(canonical);
+    const canonicalValue = base[canonicalKey];
+    if (!canonicalValue) continue;
+    for (const alias of ALIASES[canonical]) {
+      const aliasKey = toKey(alias);
+      if (!base[aliasKey]) base[aliasKey] = canonicalValue;
+    }
+  }
+
+  return base;
+}
+
+function fillAcrossDelimiters(body: string, expanded: Record<string, string>) {
+  let next = body;
+  for (const pattern of PLACEHOLDER_PATTERNS) {
+    next = next.replace(pattern, (_, raw: string) => {
+      const key = toKey(raw);
+      return expanded[key] ? expanded[key] : `[${raw}]`;
+    });
+  }
+
+  next = next.replace(/\[(number of .+?)\]/gi, (_, raw: string) => {
+    const match = /^number of (.+)$/i.exec(raw);
+    if (!match) return `[${raw}]`;
+    const baseKey = toKey(match[1]);
+    const variations = [
+      baseKey,
+      baseKey.replace(/s\b/, ""),
+      baseKey.replace(/s\b/, "") + "s",
+    ];
+    for (const candidate of variations) {
+      if (expanded[candidate]) return expanded[candidate];
+    }
+    return `[${raw}]`;
+  });
+
+  return next;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n/g, "<br/>");
+}
+
+async function safeCopy(text: string) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {}
+
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+type ChipProps = {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+};
+
+function Chip({ label, active, onClick }: ChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`chip${active ? " chip--active" : ""}`}
+      title={label}
+    >
+      {label}
+    </button>
+  );
+}
+
+type PromptCardProps = {
+  prompt: Prompt;
+  vars: Record<string, string>;
+};
+
+function PromptCard({ prompt, vars }: PromptCardProps) {
+  const [filled, setFilled] = useState<string | null>(null);
+  const expanded = useMemo(() => buildExpandedVars(vars), [vars]);
+  const currentBody = filled ?? prompt.body;
+
+  return (
+    <article className="prompt-card">
+      <div className="prompt-card__head">
+        <div>
+          <div className="prompt-card__meta">
+            {prompt.category || "Other"}
+          </div>
+          <h3 className="prompt-card__title">{prompt.title}</h3>
+        </div>
+        <div className="prompt-card__actions">
+          <button
+            type="button"
+            className="button"
+            onClick={() => setFilled(fillAcrossDelimiters(prompt.body, expanded))}
+          >
+            Insert listing details
+          </button>
+          <button
+            type="button"
+            className="button button--ghost"
+            onClick={async () => {
+              const ok = await safeCopy(currentBody);
+              if (!ok)
+                alert("Copy blocked. Please select the text and use Cmd/Ctrl + C.");
+            }}
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="prompt-card__body"
+        dangerouslySetInnerHTML={{ __html: escapeHtml(currentBody) }}
+      />
+
+      {!!(prompt.keywords && prompt.keywords.length) && (
+        <div className="prompt-card__tags">
+          {prompt.keywords!.map((keyword) => (
+            <span key={keyword} className="prompt-card__tag">
+              #{keyword}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function App() {
+  const prompts: Prompt[] = useMemo(() => {
+    const list = (rawPrompts as Prompt[]) || [];
+    return list.map((prompt, index) => ({
+      id: String(prompt.id ?? index),
+      title: prompt.title ?? `Untitled #${index + 1}`,
+      category: prompt.category ?? "Other",
+      keywords: Array.isArray(prompt.keywords) ? prompt.keywords : [],
+      body: prompt.body ?? (prompt as any).text ?? (prompt as any).prompt ?? "",
+    }));
+  }, []);
+
+  const keywordGroups: KeywordGroup[] = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+
+    prompts.forEach((prompt) => {
+      const category = (prompt.category || "Other").trim() || "Other";
+      if (!map.has(category)) map.set(category, new Set());
+      (prompt.keywords || []).forEach((keyword) => {
+        if (!keyword) return;
+        map.get(category)!.add(keyword);
+      });
+    });
+
+    return Array.from(map.entries())
+      .map(([category, keywords]) => ({
+        category,
+        keywords: Array.from(keywords).sort((a, b) => a.localeCompare(b)),
+      }))
+      .filter((group) => group.keywords.length > 0)
+      .sort((a, b) => a.category.localeCompare(b.category));
+  }, [prompts]);
+
+  const keywordUniverse = useMemo(() => {
+    const seen = new Set<string>();
+    keywordGroups.forEach((group) => {
+      group.keywords.forEach((keyword) => seen.add(keyword));
+    });
+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
+  }, [keywordGroups]);
+
+  const [search, setSearch] = useState("");
+  const [selectedKeywords, setSelectedKeywords] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  const activeKeywords = useMemo(
+    () => keywordUniverse.filter((keyword) => selectedKeywords.has(keyword)),
+    [keywordUniverse, selectedKeywords]
+  );
+
+  const selectedKeywordsList = useMemo(
+    () => Array.from(selectedKeywords).sort((a, b) => a.localeCompare(b)),
+    [selectedKeywords]
+  );
+
+  const summaryKeywords =
+    activeKeywords.length > 0 ? activeKeywords : selectedKeywordsList;
+
+  const [vars, setVars] = useState<Record<string, string>>({
+    "property type": "",
+    address: "",
+    city: "Miami",
+    neighborhood: "",
+    bedrooms: "3",
+    bathrooms: "2",
+    sqft: "",
+    price: "",
+    "hoa fee": "",
+    "year built": "",
+    "lot size": "",
+    "school district": "",
+    "key features": "ocean views, smart-home, chef’s kitchen",
+    "neighborhood characteristics": "",
+    "lifestyle benefits": "",
+    "word count": "170",
+    date: "",
+    "start time": "",
+    "end time": "",
+    "lead source": "",
+  });
+
+  const labels: string[] = [
+    "property type",
+    "address",
+    "city",
+    "neighborhood",
+    "bedrooms",
+    "bathrooms",
+    "sqft",
+    "price",
+    "hoa fee",
+    "year built",
+    "lot size",
+    "school district",
+    "key features",
+    "neighborhood characteristics",
+    "lifestyle benefits",
+    "word count",
+    "date",
+    "start time",
+    "end time",
+    "lead source",
+  ];
+
+  const filteredPrompts = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return prompts.filter((prompt) => {
+      if (selectedKeywords.size > 0) {
+        const hasKeyword = (prompt.keywords || []).some((keyword) =>
+          selectedKeywords.has(keyword)
+        );
+        if (!hasKeyword) return false;
+      }
+
+      if (!query) return true;
+      const haystack = (
+        prompt.title +
+        "\n" +
+        prompt.body +
+        "\n" +
+        (prompt.keywords || []).join(" ")
+      ).toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [prompts, search, selectedKeywords]);
+
+  const toggleKeyword = (keyword: string) => {
+    setSelectedKeywords((previous) => {
+      const next = new Set(previous);
+      if (next.has(keyword)) next.delete(keyword);
+      else next.add(keyword);
+      return next;
+    });
+  };
+
+  const clearKeywordFilters = () => setSelectedKeywords(new Set());
+
+  const clearInputs = () => {
+    setVars((current) => {
+      const cleared: Record<string, string> = {};
+      Object.keys(current).forEach((key) => {
+        cleared[key] = "";
+      });
+      return cleared;
+    });
+  };
+
+  return (
+    <div className="app-shell">
+      <div className="app-top">
+        <aside className="card">
+          <div className="inputs-grid">
+            {labels.map((label) => {
+              const id = `field-${label.replace(/\s+/g, "-")}`;
+              return (
+                <label key={label} className="field" htmlFor={id}>
+                  <span className="field__label">[{label}]</span>
+                  <input
+                    id={id}
+                    value={vars[label] ?? ""}
+                    onChange={(event) =>
+                      setVars((previous) => ({
+                        ...previous,
+                        [label]: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+              );
+            })}
+          </div>
+
+          <div className="actions">
+            <button type="button" className="button" onClick={clearInputs}>
+              Clear
+            </button>
+          </div>
+        </aside>
+
+        <div className="col-right">
+          <section className="card search-card">
+            <label htmlFor="search">Search</label>
+            <input
+              id="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search titles, bodies, keywords…"
+            />
+            <p className="muted">
+              Showing {filteredPrompts.length} of {prompts.length}
+            </p>
+          </section>
+
+          <section className="card keywords-card">
+            <div className="card__header" style={{ marginBottom: 0 }}>
+              <h2 className="card__title">Keywords</h2>
+            </div>
+            <div className="keyword-groups">
+              {keywordGroups.length === 0 ? (
+                <p className="muted">No keywords available.</p>
+              ) : (
+                keywordGroups.map(({ category, keywords }) => (
+                  <div key={category} className="keyword-group">
+                    <h3 className="keyword-group__title">{category}</h3>
+                    <div className="chip-grid">
+                      {keywords.map((keyword) => (
+                        <Chip
+                          key={`${category}-${keyword}`}
+                          label={keyword}
+                          active={selectedKeywords.has(keyword)}
+                          onClick={() => toggleKeyword(keyword)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+            {selectedKeywords.size > 0 && (
+              <div className="keyword-summary">
+                Active: {summaryKeywords.join(", ")} —{" "}
+                <button
+                  type="button"
+                  className="link-button"
+                  onClick={clearKeywordFilters}
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+
+      <section className="grid-section">
+        {filteredPrompts.length > 0 ? (
+          <div className="grid">
+            {filteredPrompts.map((prompt) => (
+              <PromptCard key={prompt.id} prompt={prompt} vars={vars} />
+            ))}
+          </div>
+        ) : (
+          <div className="empty-state">
+            No prompts match your filters yet. Try adjusting the search or
+            keyword chips.
+          </div>
+        )}
+      </section>
+
+      <footer className="footer">
+        © {new Date().getFullYear()} Busy Realtors Time Saviour — Prompt finder
+        toolkit
+      </footer>
+    </div>
+  );
+}
  
-EOF
-)

--- a/src/index.css
+++ b/src/index.css
@@ -1,825 +1,350 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/src/index.css b/src/index.css
-index 83d8ff051647109fcd18dedc4498509cff608038..2e73b5ffe2aad851ad3bfe175e7c2a5f5e91b1b1 100644
---- a/src/index.css
-+++ b/src/index.css
-@@ -1,481 +1,335 @@
-- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
--diff --git a/src/index.css b/src/index.css
--index 3a1d427ee07d903be02b96ccb87d37a49ea90516..1c90a68d94e7fbb89e27c486e11bebe12ae8e488 100644
----- a/src/index.css
--+++ b/src/index.css
--@@ -1,7 +1,469 @@
-- @tailwind base;
-- @tailwind components;
-- @tailwind utilities;
-- 
---/* Premium background helpers */
---.bg-radial-a { background: radial-gradient(closest-side, #12D6DF55, transparent); }
---.bg-radial-b { background: radial-gradient(closest-side, #7C9CFF55, transparent); }
--+/* Base theming */
--+*:where(*) {
--+  box-sizing: border-box;
--+}
--+
--+:root {
--+  color-scheme: dark;
--+  font-family: "Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system,
--+    BlinkMacSystemFont, "Helvetica Neue", sans-serif;
--+  background-color: #05060e;
--+}
--+
--+body {
--+  margin: 0;
--+  min-height: 100vh;
--+  background-image: radial-gradient(circle at top left, #294cff38 0%, transparent 46%),
--+    radial-gradient(circle at bottom right, #12d6df38 0%, transparent 54%),
--+    linear-gradient(165deg, #05060e 0%, #090c19 55%, #03040c 100%);
--+  color: #fff;
--+  display: flex;
--+  justify-content: center;
--+  padding: clamp(18px, 4vw, 36px);
--+}
--+
--+#root {
--+  width: 100%;
--+}
--+
--+/* Layout shell */
--+.__brts__root {
--+  width: min(1200px, 100%);
--+  margin: 0 auto;
--+  padding: clamp(18px, 3vw, 32px);
--+  color: #fff;
--+  display: flex;
--+  flex-direction: column;
--+  gap: 28px;
--+  position: relative;
--+  z-index: 0;
--+}
--+
--+.__brts__root::before {
--+  content: "";
--+  position: absolute;
--+  inset: 0;
--+  border-radius: 34px;
--+  background: linear-gradient(120deg, rgba(124, 156, 255, 0.18), rgba(18, 214, 223, 0.1));
--+  filter: blur(160px);
--+  opacity: 0.7;
--+  pointer-events: none;
--+}
--+
--+.__header {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 12px;
--+  position: relative;
--+  z-index: 1;
--+}
--+
--+.__eyebrow {
--+  text-transform: uppercase;
--+  font-size: 0.78rem;
--+  letter-spacing: 0.32em;
--+  color: rgba(124, 156, 255, 0.9);
--+  font-weight: 600;
--+}
--+
--+.__title {
--+  margin: 0;
--+  font-weight: 800;
--+  line-height: 1.05;
--+  font-size: clamp(2rem, 3.4vw, 3.2rem);
--+  display: flex;
--+  flex-direction: column;
--+  gap: 8px;
--+  text-shadow: 0 14px 40px rgba(7, 11, 27, 0.65);
--+}
--+
--+.__titleNote {
--+  font-size: clamp(1rem, 2.1vw, 1.2rem);
--+  font-weight: 500;
--+  color: rgba(255, 255, 255, 0.78);
--+  letter-spacing: 0.06em;
--+}
--+
--+.__sub {
--+  opacity: 0.78;
--+  max-width: 780px;
--+  margin: 0;
--+  font-size: clamp(0.95rem, 1.7vw, 1.1rem);
--+}
--+
--+.__layout {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 28px;
--+  position: relative;
--+  z-index: 1;
--+}
--+
--+.__topRow {
--+  display: grid;
--+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
--+  gap: 22px;
--+  align-items: start;
--+}
--+
--+.__colRight {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 16px;
--+}
--+
--+.__card {
--+  border: 1px solid rgba(255, 255, 255, 0.12);
--+  background: linear-gradient(165deg, rgba(18, 24, 40, 0.92), rgba(18, 24, 40, 0.72));
--+  backdrop-filter: blur(14px);
--+  border-radius: 22px;
--+  padding: 22px;
--+  box-shadow: 0 16px 48px rgba(6, 9, 20, 0.55);
--+  position: relative;
--+  overflow: hidden;
--+}
--+
--+.__card::after {
--+  content: "";
--+  position: absolute;
--+  inset: 1px;
--+  border-radius: 20px;
--+  border: 1px solid rgba(255, 255, 255, 0.06);
--+  pointer-events: none;
--+}
--+
--+.__card h3 {
--+  margin: 0 0 0.75rem 0;
--+  font-size: 1.08rem;
--+}
--+
--+.__card--details {
--+  position: relative;
--+}
--+
--+.__card--keywords {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 18px;
--+}
--+
--+.__keywordSummary {
--+  font-size: 0.82rem;
--+  opacity: 0.76;
--+}
--+
--+.__cardTitleRow {
--+  display: flex;
--+  align-items: center;
--+  justify-content: space-between;
--+  gap: 12px;
--+}
--+
--+.__badge {
--+  background: linear-gradient(120deg, #7c9cff, #12d6df);
--+  color: #05060e;
--+  border-radius: 999px;
--+  padding: 4px 12px;
--+  font-size: 0.68rem;
--+  letter-spacing: 0.14em;
--+  font-weight: 700;
--+  text-transform: uppercase;
--+}
--+
--+.__inputs {
--+  display: grid;
--+  grid-template-columns: repeat(2, minmax(0, 1fr));
--+  gap: 14px 16px;
--+}
--+
--+.__field {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 6px;
--+}
--+
--+.__inputs label {
--+  font-size: 0.72rem;
--+  opacity: 0.75;
--+  letter-spacing: 0.04em;
--+}
--+
--+.__inputs input {
--+  width: 100%;
--+  border-radius: 12px;
--+  border: 1px solid rgba(255, 255, 255, 0.18);
--+  background: rgba(8, 11, 20, 0.92);
--+  color: #fff;
--+  padding: 9px 12px;
--+  outline: none;
--+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
--+}
--+
--+.__inputs input:focus {
--+  border-color: rgba(124, 156, 255, 0.85);
--+  box-shadow: 0 0 0 2px rgba(124, 156, 255, 0.2);
--+}
--+
--+.__actionsRow {
--+  display: flex;
--+  gap: 10px;
--+  margin-top: 18px;
--+  flex-wrap: wrap;
--+}
--+
--+.__search label {
--+  font-size: 0.8rem;
--+  letter-spacing: 0.08em;
--+  text-transform: uppercase;
--+  opacity: 0.74;
--+}
--+
--+.__search input {
--+  width: 100%;
--+  margin-top: 10px;
--+  border-radius: 12px;
--+  border: 1px solid rgba(255, 255, 255, 0.18);
--+  background: rgba(8, 11, 20, 0.92);
--+  color: #fff;
--+  padding: 10px 12px;
--+  outline: none;
--+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
--+}
--+
--+.__search input:focus {
--+  border-color: rgba(18, 214, 223, 0.85);
--+  box-shadow: 0 0 0 2px rgba(18, 214, 223, 0.2);
--+}
--+
--+.__muted {
--+  opacity: 0.72;
--+  font-size: 0.75rem;
--+}
--+
--+.__muted--spaced {
--+  margin-top: 10px;
--+}
--+
--+.__linkBtn {
--+  appearance: none;
--+  background: none;
--+  border: none;
--+  color: #fff;
--+  font-size: 0.75rem;
--+  text-decoration: underline;
--+  cursor: pointer;
--+  padding: 0;
--+}
--+
--+.__keywordGroups {
--+  display: grid;
--+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
--+  gap: 18px;
--+}
--+
--+.__keywordGroup {
--+  display: flex;
--+  flex-direction: column;
--+  gap: 12px;
--+  padding: 16px;
--+  border-radius: 16px;
--+  border: 1px solid rgba(255, 255, 255, 0.18);
--+  background: rgba(6, 12, 24, 0.48);
--+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
--+}
--+
--+.__keywordGroupHead {
--+  display: flex;
--+  justify-content: space-between;
--+  align-items: baseline;
--+  gap: 12px;
--+}
--+
--+.__groupTitle {
--+  margin: 0;
--+  font-size: 0.95rem;
--+  letter-spacing: 0.12em;
--+  text-transform: uppercase;
--+  opacity: 0.82;
--+}
--+
--+.__groupMeta {
--+  font-size: 0.7rem;
--+  letter-spacing: 0.08em;
--+  text-transform: uppercase;
--+  opacity: 0.6;
--+}
--+
--+.__chipsWrap {
--+  display: flex;
--+  flex-wrap: wrap;
--+  gap: 8px;
--+}
--+
--+.__chip {
--+  padding: 7px 14px;
--+  border-radius: 999px;
--+  border: 1px solid rgba(255, 255, 255, 0.2);
--+  background: rgba(255, 255, 255, 0.08);
--+  font-size: 0.75rem;
--+  color: #fff;
--+  cursor: pointer;
--+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease,
--+    color 0.2s ease;
--+}
--+
--+.__chip:hover {
--+  transform: translateY(-1px);
--+  border-color: rgba(124, 156, 255, 0.7);
--+}
--+
--+.__chip--active {
--+  background: linear-gradient(120deg, #7c9cff, #12d6df);
--+  color: #05060e;
--+  border-color: transparent;
--+  box-shadow: 0 8px 18px rgba(18, 214, 223, 0.35);
--+}
--+
--+.__gridSection {
--+  width: 100%;
--+  margin-top: 6px;
--+}
--+
--+.__grid {
--+  display: grid;
--+  grid-template-columns: repeat(3, minmax(0, 1fr));
--+  gap: 18px;
--+}
--+
--+.__pCard {
--+  border: 1px solid rgba(255, 255, 255, 0.12);
--+  background: linear-gradient(170deg, rgba(18, 24, 40, 0.9), rgba(14, 18, 32, 0.8));
--+  border-radius: 20px;
--+  padding: 22px;
--+  display: flex;
--+  flex-direction: column;
--+  gap: 16px;
--+  box-shadow: 0 16px 38px rgba(5, 8, 18, 0.4);
--+  position: relative;
--+}
--+
--+.__pHead {
--+  display: flex;
--+  justify-content: space-between;
--+  gap: 14px;
--+  flex-wrap: wrap;
--+}
--+
--+.__cat {
--+  font-size: 0.7rem;
--+  text-transform: uppercase;
--+  opacity: 0.66;
--+  letter-spacing: 0.16em;
--+}
--+
--+.__pTitle {
--+  margin: 6px 0 0 0;
--+}
--+
--+.__btns {
--+  display: flex;
--+  gap: 10px;
--+  flex-wrap: wrap;
--+}
--+
--+.__btn {
--+  padding: 10px 14px;
--+  border-radius: 12px;
--+  border: 1px solid rgba(255, 255, 255, 0.25);
--+  background: linear-gradient(115deg, #ffffff, #d7e4ff);
--+  color: #091020;
--+  font-weight: 700;
--+  cursor: pointer;
--+  transition: transform 0.2s ease, box-shadow 0.2s ease;
--+}
--+
--+.__btn:active {
--+  transform: translateY(1px);
--+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.25);
--+}
--+
--+.__chipsRow {
--+  display: flex;
--+  flex-wrap: wrap;
--+  gap: 6px;
--+  margin-top: -4px;
--+}
--+
--+.__chipTag {
--+  padding: 4px 8px;
--+  border-radius: 999px;
--+  border: 1px solid rgba(255, 255, 255, 0.12);
--+  background: rgba(255, 255, 255, 0.1);
--+  font-size: 0.7rem;
--+}
--+
--+.__pBody {
--+  line-height: 1.65;
--+  white-space: pre-wrap;
--+}
--+
--+.__footer {
--+  padding: 28px 0 34px;
--+  opacity: 0.6;
--+  font-size: 0.75rem;
--+  text-align: center;
--+}
--+
--+/* Responsiveness */
--+@media (max-width: 1199px) {
--+  .__grid {
--+    grid-template-columns: repeat(2, minmax(0, 1fr));
--+  }
--+}
--+
--+@media (max-width: 980px) {
--+  body {
--+    padding: clamp(14px, 6vw, 28px);
--+  }
--+
--+  .__topRow {
--+    grid-template-columns: minmax(0, 1fr);
--+  }
--+
--+  .__card {
--+    padding: 20px;
--+  }
--+}
--+
--+@media (max-width: 720px) {
--+  .__inputs {
--+    grid-template-columns: 1fr;
--+  }
--+
--+  .__grid {
--+    grid-template-columns: minmax(0, 1fr);
--+  }
--+
--+  .__btns {
--+    width: 100%;
--+  }
--+
--+  .__btns .__btn {
--+    flex: 1 1 auto;
--+  }
--+}
--+
--+@media (max-width: 540px) {
--+  .__title {
--+    font-size: clamp(1.8rem, 8vw, 2.2rem);
--+  }
--+
--+  .__titleNote {
--+    font-size: 0.95rem;
--+  }
--+}
--+
-- 
--EOF
--)
-+:root {
-+  color-scheme: dark;
-+  font-family: "Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system,
-+    BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-+  background-color: #05060e;
-+  color: #fff;
-+}
-+
-+* {
-+  box-sizing: border-box;
-+}
-+
-+body {
-+  margin: 0;
-+  min-height: 100vh;
-+  background: radial-gradient(circle at top left, rgba(124, 156, 255, 0.15), transparent 55%),
-+    radial-gradient(circle at bottom right, rgba(18, 214, 223, 0.12), transparent 60%),
-+    linear-gradient(165deg, #05060e 0%, #090c19 55%, #03040c 100%);
-+  display: flex;
-+  justify-content: center;
-+  padding: clamp(16px, 4vw, 40px);
-+}
-+
-+#root {
-+  width: 100%;
-+}
-+
-+.app-shell {
-+  width: min(1200px, 100%);
-+  margin: 0 auto;
-+  display: flex;
-+  flex-direction: column;
-+  gap: 24px;
-+}
-+
-+.app-top {
-+  display: grid;
-+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
-+  gap: 18px;
-+  align-items: flex-start;
-+}
-+
-+@media (max-width: 1024px) {
-+  .app-top {
-+    grid-template-columns: 1fr;
-+  }
-+}
-+
-+.col-right {
-+  display: flex;
-+  flex-direction: column;
-+  gap: 16px;
-+}
-+
-+.card {
-+  background: rgba(18, 24, 40, 0.85);
-+  border: 1px solid rgba(255, 255, 255, 0.12);
-+  border-radius: 20px;
-+  padding: 20px;
-+  box-shadow: 0 18px 38px rgba(5, 8, 18, 0.4);
-+  backdrop-filter: blur(10px);
-+}
-+
-+.card__header {
-+  display: flex;
-+  align-items: center;
-+  justify-content: space-between;
-+  gap: 12px;
-+  margin-bottom: 16px;
-+}
-+
-+.card__title {
-+  margin: 0;
-+  font-size: 1.05rem;
-+  letter-spacing: 0.08em;
-+  text-transform: uppercase;
-+}
-+
-+.card__badge {
-+  background: linear-gradient(120deg, #7c9cff, #12d6df);
-+  color: #05060e;
-+  border-radius: 999px;
-+  padding: 4px 12px;
-+  font-size: 0.68rem;
-+  letter-spacing: 0.12em;
-+  font-weight: 700;
-+  text-transform: uppercase;
-+}
-+
-+.inputs-grid {
-+  display: grid;
-+  grid-template-columns: repeat(2, minmax(0, 1fr));
-+  gap: 12px 16px;
-+}
-+
-+@media (max-width: 720px) {
-+  .inputs-grid {
-+    grid-template-columns: 1fr;
-+  }
-+}
-+
-+.field {
-+  display: flex;
-+  flex-direction: column;
-+  gap: 6px;
-+}
-+
-+.field__label {
-+  font-size: 0.75rem;
-+  letter-spacing: 0.05em;
-+  opacity: 0.72;
-+  text-transform: uppercase;
-+}
-+
-+.field input {
-+  width: 100%;
-+  border-radius: 12px;
-+  border: 1px solid rgba(255, 255, 255, 0.18);
-+  background: rgba(8, 11, 20, 0.92);
-+  color: #fff;
-+  padding: 10px 12px;
-+  outline: none;
-+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-+}
-+
-+.field input:focus {
-+  border-color: rgba(124, 156, 255, 0.85);
-+  box-shadow: 0 0 0 2px rgba(124, 156, 255, 0.2);
-+}
-+
-+.actions {
-+  display: flex;
-+  gap: 10px;
-+  margin-top: 18px;
-+  flex-wrap: wrap;
-+}
-+
-+.button {
-+  padding: 9px 14px;
-+  border-radius: 12px;
-+  border: 1px solid rgba(255, 255, 255, 0.22);
-+  background: #fff;
-+  color: #05060e;
-+  font-weight: 600;
-+  letter-spacing: 0.04em;
-+  cursor: pointer;
-+  transition: transform 0.15s ease, box-shadow 0.15s ease;
-+}
-+
-+.button:hover {
-+  transform: translateY(-1px);
-+  box-shadow: 0 10px 22px rgba(18, 214, 223, 0.3);
-+}
-+
-+.button--ghost {
-+  background: transparent;
-+  color: #fff;
-+}
-+
-+.button--ghost:hover {
-+  border-color: rgba(124, 156, 255, 0.6);
-+  box-shadow: none;
-+}
-+
-+.search-card label {
-+  font-size: 0.78rem;
-+  letter-spacing: 0.08em;
-+  text-transform: uppercase;
-+  opacity: 0.75;
-+}
-+
-+.search-card input {
-+  width: 100%;
-+  margin-top: 10px;
-+  border-radius: 12px;
-+  border: 1px solid rgba(255, 255, 255, 0.18);
-+  background: rgba(8, 11, 20, 0.92);
-+  color: #fff;
-+  padding: 10px 12px;
-+  outline: none;
-+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-+}
-+
-+.search-card input:focus {
-+  border-color: rgba(18, 214, 223, 0.85);
-+  box-shadow: 0 0 0 2px rgba(18, 214, 223, 0.2);
-+}
-+
-+.muted {
-+  opacity: 0.72;
-+  font-size: 0.75rem;
-+  margin-top: 10px;
-+}
-+
-+.keywords-card {
-+  display: flex;
-+  flex-direction: column;
-+  gap: 16px;
-+}
-+
-+.chip-grid {
-+  display: flex;
-+  flex-wrap: wrap;
-+  gap: 8px;
-+}
-+
-+.chip {
-+  padding: 7px 14px;
-+  border-radius: 999px;
-+  border: 1px solid rgba(255, 255, 255, 0.22);
-+  background: rgba(255, 255, 255, 0.08);
-+  font-size: 0.75rem;
-+  color: #fff;
-+  cursor: pointer;
-+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease,
-+    color 0.2s ease;
-+}
-+
-+.chip:hover {
-+  transform: translateY(-1px);
-+  border-color: rgba(124, 156, 255, 0.7);
-+}
-+
-+.chip--active {
-+  background: linear-gradient(120deg, #7c9cff, #12d6df);
-+  color: #05060e;
-+  border-color: transparent;
-+  box-shadow: 0 8px 18px rgba(18, 214, 223, 0.35);
-+}
-+
-+.keyword-summary {
-+  font-size: 0.78rem;
-+  opacity: 0.78;
-+}
-+
-+.link-button {
-+  appearance: none;
-+  background: none;
-+  border: none;
-+  color: #fff;
-+  font-size: 0.78rem;
-+  text-decoration: underline;
-+  cursor: pointer;
-+  padding: 0;
-+}
-+
-+.grid-section {
-+  width: 100%;
-+}
-+
-+.grid {
-+  display: grid;
-+  grid-template-columns: repeat(3, minmax(0, 1fr));
-+  gap: 18px;
-+}
-+
-+@media (max-width: 1200px) {
-+  .grid {
-+    grid-template-columns: repeat(2, minmax(0, 1fr));
-+  }
-+}
-+
-+@media (max-width: 720px) {
-+  .grid {
-+    grid-template-columns: 1fr;
-+  }
-+}
-+
-+.prompt-card {
-+  border: 1px solid rgba(255, 255, 255, 0.12);
-+  background: linear-gradient(170deg, rgba(18, 24, 40, 0.9), rgba(14, 18, 32, 0.82));
-+  border-radius: 20px;
-+  padding: 22px;
-+  display: flex;
-+  flex-direction: column;
-+  gap: 16px;
-+  box-shadow: 0 16px 38px rgba(5, 8, 18, 0.4);
-+}
-+
-+.prompt-card__head {
-+  display: flex;
-+  justify-content: space-between;
-+  gap: 12px;
-+}
-+
-+.prompt-card__meta {
-+  font-size: 0.7rem;
-+  letter-spacing: 0.12em;
-+  text-transform: uppercase;
-+  opacity: 0.6;
-+}
-+
-+.prompt-card__title {
-+  margin: 6px 0 0 0;
-+  font-size: 1.05rem;
-+}
-+
-+.prompt-card__actions {
-+  display: flex;
-+  gap: 8px;
-+  flex-wrap: wrap;
-+}
-+
-+.prompt-card__body {
-+  white-space: pre-wrap;
-+}
-+
-+.prompt-card__tags {
-+  display: flex;
-+  flex-wrap: wrap;
-+  gap: 6px;
-+}
-+
-+.prompt-card__tag {
-+  padding: 4px 8px;
-+  border-radius: 999px;
-+  border: 1px solid rgba(255, 255, 255, 0.12);
-+  background: rgba(255, 255, 255, 0.08);
-+  font-size: 0.7rem;
-+}
-+
-+.empty-state {
-+  padding: 24px;
-+  border-radius: 16px;
-+  border: 1px dashed rgba(255, 255, 255, 0.2);
-+  text-align: center;
-+  opacity: 0.75;
-+}
-+
-+.footer {
-+  padding: 24px 0;
-+  font-size: 0.75rem;
-+  opacity: 0.7;
-+  text-align: center;
-+}
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system,
+    BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  background-color: #05060e;
+  color: #fff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(124, 156, 255, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(18, 214, 223, 0.12), transparent 60%),
+    linear-gradient(165deg, #05060e 0%, #090c19 55%, #03040c 100%);
+  display: flex;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 40px);
+}
+
+#root {
+  width: 100%;
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-top {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: flex-start;
+}
+
+@media (max-width: 1024px) {
+  .app-top {
+    grid-template-columns: 1fr;
+  }
+}
+
+.col-right {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: rgba(18, 24, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 18px 38px rgba(5, 8, 18, 0.4);
+  backdrop-filter: blur(10px);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.inputs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
+}
+
+@media (max-width: 720px) {
+  .inputs-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  opacity: 0.72;
+  text-transform: uppercase;
+}
+
+.field input {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 11, 20, 0.92);
+  color: #fff;
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+  border-color: rgba(124, 156, 255, 0.85);
+  box-shadow: 0 0 0 2px rgba(124, 156, 255, 0.2);
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: 9px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: #fff;
+  color: #05060e;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(18, 214, 223, 0.3);
+}
+
+.button--ghost {
+  background: transparent;
+  color: #fff;
+}
+
+.button--ghost:hover {
+  border-color: rgba(124, 156, 255, 0.6);
+  box-shadow: none;
+}
+
+.search-card label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.search-card input {
+  width: 100%;
+  margin-top: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 11, 20, 0.92);
+  color: #fff;
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-card input:focus {
+  border-color: rgba(18, 214, 223, 0.85);
+  box-shadow: 0 0 0 2px rgba(18, 214, 223, 0.2);
+}
+
+.muted {
+  opacity: 0.72;
+  font-size: 0.75rem;
+  margin-top: 10px;
+}
+
+.keywords-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.keyword-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.keyword-groups > .muted {
+  margin: 4px 0 0;
+  text-align: center;
+}
+
+.keyword-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.keyword-group__title {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.75rem;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(124, 156, 255, 0.7);
+}
+
+.chip--active {
+  background: linear-gradient(120deg, #7c9cff, #12d6df);
+  color: #05060e;
+  border-color: transparent;
+  box-shadow: 0 8px 18px rgba(18, 214, 223, 0.35);
+}
+
+.keyword-summary {
+  font-size: 0.78rem;
+  opacity: 0.78;
+}
+
+.link-button {
+  appearance: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.grid-section {
+  width: 100%;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+@media (max-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.prompt-card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(170deg, rgba(18, 24, 40, 0.9), rgba(14, 18, 32, 0.82));
+  border-radius: 20px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 16px 38px rgba(5, 8, 18, 0.4);
+}
+
+.prompt-card__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.prompt-card__meta {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.prompt-card__title {
+  margin: 6px 0 0 0;
+  font-size: 1.05rem;
+}
+
+.prompt-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.prompt-card__body {
+  white-space: pre-wrap;
+}
+
+.prompt-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.prompt-card__tag {
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.7rem;
+}
+
+.empty-state {
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  text-align: center;
+  opacity: 0.75;
+}
+
+.footer {
+  padding: 24px 0;
+  font-size: 0.75rem;
+  opacity: 0.7;
+  text-align: center;
+}
  
-EOF
-)


### PR DESCRIPTION
## Summary
- remove the listing card title/subtitle so the inputs start without a header
- group keywords by their category in the keyword picker with an empty-state fallback
- refresh supporting styles and add a gitignore for build artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafa4dfe00832d96a0e799f73377ca